### PR TITLE
change trigger event to pull_request

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,14 +2,15 @@ name: terraform CI
 on:
   pull_request:
     paths:
-      - ./cicd/**
+      - 'cicd/**'
+      - '.github/workflows/cicd.yml'
 
 jobs:
   terraform-ci:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./cicd
+        working-directory: cicd
     env:
       GOOGLE_BACKEND_CREDENTIALS: ${{ secrets.TF_API_TOKEN }}
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,7 @@
 name: terraform CI
 on:
   pull_request:
+    branches: [develop]
     paths:
       - 'cicd/**'
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,7 @@ on:
     branches: [develop]
     paths:
       - 'cicd/**'
+      - '.github/workflows/cicd.yml'
 
 jobs:
   terraform-ci:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,8 @@
 name: terraform CI
-on: push
+on:
+  pull_request:
+    paths:
+      - ./cicd/**
 
 jobs:
   terraform-ci:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     paths:
       - 'cicd/**'
-      - '.github/workflows/cicd.yml'
 
 jobs:
   terraform-ci:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ CI/CD workflowの設定 (/cicd)
 - [GitHub Actions 実践入門 booth](https://miyajan.booth.pm/items/1865906)
   - [action-tflint](https://github.com/reviewdog/action-tflint)
   - [setup-terraform](https://github.com/hashicorp/setup-terraform) because hashicorp/terraform-github-actions repository is no longer active
+  - pull_request event
+    - https://docs.github.com/ja/actions/reference/workflow-syntax-for-github-actions
+    - https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#webhook-events
+    - https://github.community/t/what-is-a-pull-request-synchronize-event/14784/3
 - [Terraform再入門2020](https://qiita.com/minamijoyo/items/3a7467f70d145ac03324)
   - [remote state を変えないで plan したい](https://qiita.com/minamijoyo/items/b4d70787556c83f289e7)
 - app 写経 定期手にslack通知 [Qiita](https://qiita.com/donko_/items/6289bb31fecfce2cda79) [GitHub](https://github.com/donkomura/TerraformPractice)


### PR DESCRIPTION
get-started ディレクトリなどがあるので、pathsの指定だけはする
typesはデフォルトの opened、synchronize、または reopened の場合で良いので、指定なし。
ブランチ指定をしない場合は、defaultブランチ(develop)がターゲットになると思う。