### PR TITLE
practice-cicd is deleted from firebase project

### DIFF
--- a/cicd/backup/state-bucket.tf
+++ b/cicd/backup/state-bucket.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket" "terraform-state-store" {
-  name          = "marltake-practice-cicd"
-  project       = var.project
+  name          = "marltake-practice-cicd-2"
+  project       = "practice-cicd-mtk"
   location      = var.region
   storage_class = "REGIONAL"
 

--- a/cicd/main.tf
+++ b/cicd/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "google" {
-  project = "practice-cicd-322801"
+  project = "practice-cicd-mtk"
   region  = var.region
   zone    = var.zone
 }

--- a/cicd/remote-state.tf
+++ b/cicd/remote-state.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket = "marltake-practice-cicd"
+    bucket = "marltake-practice-cicd-2"
     prefix = "develop"
   }
 }


### PR DESCRIPTION
firebaseプロジェクトをpractice-cicdにして作成して削除したらGCPもまとめて削除された。プロジェクトの削除だからそれはそう。削除の注意事項がちゃんと実行された。
プロジェクト名 practice-cicd-mtk、state-bucket名 marltake-practice-cicd-2 でプロジェクトを再作成する。
サービスアカウントとそのキーも再作成して、再登録した。